### PR TITLE
Fix DB Write Speed

### DIFF
--- a/app/schemas/sam.g.trackuriboh.data.db.AppDatabase/3.json
+++ b/app/schemas/sam.g.trackuriboh.data.db.AppDatabase/3.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 2,
+    "version": 3,
     "identityHash": "30df1d2a72a1858c601f17988170aa7e",
     "entities": [
       {

--- a/app/src/main/java/sam/g/trackuriboh/data/db/AppDatabase.kt
+++ b/app/src/main/java/sam/g/trackuriboh/data/db/AppDatabase.kt
@@ -10,6 +10,7 @@ import sam.g.trackuriboh.data.db.converters.RoomConverter
 import sam.g.trackuriboh.data.db.dao.*
 import sam.g.trackuriboh.data.db.entities.*
 import sam.g.trackuriboh.data.db.migrations.MIGRATION_1_2
+import sam.g.trackuriboh.data.db.migrations.MIGRATION_2_3
 
 @Database(
     entities = [
@@ -23,7 +24,7 @@ import sam.g.trackuriboh.data.db.migrations.MIGRATION_1_2
         UserList::class,
         UserListEntry::class,
     ],
-    version = 2
+    version = 3
 )
 @TypeConverters(RoomConverter::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -76,6 +77,6 @@ abstract class AppDatabase : RoomDatabase() {
                 if (!BuildConfig.DEBUG) {
                     createFromAsset(DATABASE_FILE_PATH)
                 }
-            }.addMigrations(MIGRATION_1_2).build()
+            }.addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
     }
 }

--- a/app/src/main/java/sam/g/trackuriboh/data/db/dao/BaseDao.kt
+++ b/app/src/main/java/sam/g/trackuriboh/data/db/dao/BaseDao.kt
@@ -26,4 +26,7 @@ interface BaseDao<T> {
 
     @Delete
     suspend fun delete(obj: T)
+
+    @Delete
+    suspend fun delete(vararg objs: T)
 }

--- a/app/src/main/java/sam/g/trackuriboh/data/db/entities/Sku.kt
+++ b/app/src/main/java/sam/g/trackuriboh/data/db/entities/Sku.kt
@@ -3,6 +3,7 @@ package sam.g.trackuriboh.data.db.entities
 import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 
@@ -24,7 +25,8 @@ import kotlinx.parcelize.Parcelize
             parentColumns = ["id"],
             childColumns = ["printingId"],
         )
-    ]
+    ],
+    indices = [Index(value = ["productId"])]
 )
 
 @Parcelize

--- a/app/src/main/java/sam/g/trackuriboh/data/db/migrations/1_2.kt
+++ b/app/src/main/java/sam/g/trackuriboh/data/db/migrations/1_2.kt
@@ -13,3 +13,9 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
         database.execSQL("CREATE TABLE `Product` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `cleanName` TEXT NOT NULL, `type` TEXT NOT NULL, `imageUrl` TEXT, `setId` INTEGER, `number` TEXT, `rarityId` INTEGER, `attribute` TEXT, `cardType` TEXT, `attack` INTEGER, `defense` INTEGER, `description` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`setId`) REFERENCES `CardSet`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`rarityId`) REFERENCES `CardRarity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
     }
 }
+
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("CREATE INDEX index_Sku_productId ON Sku(productId)")
+    }
+}


### PR DESCRIPTION
Changes:
- Add `Index` to `ProductId` Column for `Sku` Table
- FlatMap SKUs

Reasoning:

Every delete / upsert of the product table requires a lookup of the `Sku` Table via the `ProductId` Column.  Since that column is not indexed, it takes a long time.